### PR TITLE
feat: improve response handling and JSON spec support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## Features
 
-- OpenAPI 3.x YAML input from a file or folder
-- Recursive scan of `.yaml` and `.yml` files
+- OpenAPI 3.x YAML or JSON input from a file or folder
+- Recursive scan of `.yaml`, `.yml`, and `.json` files
 - Realistic mock values for common fields
 - Automatic merge for multiple specifications
 - Swagger UI at `/api-docs`
@@ -55,23 +55,21 @@ api-mock --help
 
 ## Multi-spec behavior
 
-- Folder input is scanned recursively for YAML files
+- Folder input is scanned recursively for YAML and JSON files
 - Specs are validated before merge
 - Duplicate paths are resolved by first occurrence
 
 ## Troubleshooting
 
 - `Path not found: ...`: check file/folder path and run from expected working directory
-- `File must be a YAML file`: input must end with `.yaml` or `.yml`
-- `Failed to parse OpenAPI specification`: validate YAML and OpenAPI structure
+- `File must be an OpenAPI spec file`: input must end with `.yaml`, `.yml`, or `.json`
+- `Failed to parse OpenAPI specification`: validate YAML/JSON and OpenAPI structure
 - `Port must be a valid number between 1 and 65535`: pass a valid numeric port
 - `EADDRINUSE`: selected port is already in use; choose another port
 
 ## Limitations
 
-- Response selection prioritizes `200`, then `201`, then `default`
-- Request body is not used to shape response data
-- Focused on OpenAPI 3 YAML input
+- Focused on OpenAPI 3 input
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ program
     .description('CLI to mock REST endpoints from OpenAPI specifications')
     .version(getCliVersion())
     .option('-p, --port <number>', 'port to run the mock server on', '3000')
-    .option('--path <path>', 'path to OpenAPI file or folder containing YAML specs', './openapi.yaml')
+    .option('--path <path>', 'path to OpenAPI file or folder containing YAML/JSON specs', './openapi.yaml')
     .action(async (options: { port: string; path: string }) => {
         try {
             const specPath = path.resolve(process.cwd(), options.path);

--- a/src/services/__tests__/server.service.test.ts
+++ b/src/services/__tests__/server.service.test.ts
@@ -2,6 +2,7 @@ import { generateMockResponse } from '../mock-generator.service';
 import { startMockServer } from '../server.service';
 import { Document, ResponseObject } from '../../types';
 import { Server } from 'http';
+import axios from 'axios';
 
 jest.setTimeout(10000);
 
@@ -58,6 +59,124 @@ describe('Server Service', () => {
             const port = 3100 + Math.floor(Math.random() * 1000);
             server = await startMockServer(mockApiSpec, port);
             expect(server).toBeDefined();
+        });
+    });
+
+    describe('Response Selection', () => {
+        it('should prioritize the lowest 2xx response', async () => {
+            const port = 4100 + Math.floor(Math.random() * 1000);
+            const apiSpec: Document = {
+                openapi: '3.0.0',
+                info: { title: 'Response API', version: '1.0.0' },
+                paths: {
+                    '/test': {
+                        get: {
+                            responses: {
+                                '202': {
+                                    description: 'Accepted',
+                                    content: {
+                                        'application/json': {
+                                            schema: {
+                                                type: 'object',
+                                                properties: { status: { type: 'string' } },
+                                            },
+                                        },
+                                    },
+                                },
+                                '400': {
+                                    description: 'Bad Request',
+                                    content: {
+                                        'application/json': {
+                                            schema: {
+                                                type: 'object',
+                                                properties: { error: { type: 'string' } },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            server = await startMockServer(apiSpec, port);
+            const response = await axios.get(`http://localhost:${port}/test`);
+            expect(response.status).toBe(202);
+            expect(response.data).toHaveProperty('status');
+        });
+    });
+
+    describe('Request Body Shaping', () => {
+        it('should shape object response using request body fields', async () => {
+            const port = 5100 + Math.floor(Math.random() * 1000);
+            const apiSpec: Document = {
+                openapi: '3.0.0',
+                info: { title: 'Body API', version: '1.0.0' },
+                paths: {
+                    '/users': {
+                        post: {
+                            requestBody: {
+                                required: true,
+                                content: {
+                                    'application/json': {
+                                        schema: {
+                                            type: 'object',
+                                            properties: {
+                                                name: { type: 'string' },
+                                                email: { type: 'string' },
+                                                profile: {
+                                                    type: 'object',
+                                                    properties: {
+                                                        city: { type: 'string' },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                            responses: {
+                                '201': {
+                                    description: 'Created',
+                                    content: {
+                                        'application/json': {
+                                            schema: {
+                                                type: 'object',
+                                                properties: {
+                                                    id: { type: 'integer' },
+                                                    name: { type: 'string' },
+                                                    email: { type: 'string' },
+                                                    profile: {
+                                                        type: 'object',
+                                                        properties: {
+                                                            city: { type: 'string' },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            server = await startMockServer(apiSpec, port);
+            const payload = {
+                name: 'Jane Doe',
+                email: 'jane@example.com',
+                profile: { city: 'Hamburg' },
+            };
+            const response = await axios.post(`http://localhost:${port}/users`, payload);
+
+            expect(response.status).toBe(201);
+            expect(response.data.name).toBe(payload.name);
+            expect(response.data.email).toBe(payload.email);
+            expect(response.data.profile.city).toBe(payload.profile.city);
+            expect(typeof response.data.id).toBe('number');
         });
     });
 });

--- a/src/services/multi-spec-server.service.ts
+++ b/src/services/multi-spec-server.service.ts
@@ -1,6 +1,6 @@
 import { Document } from '../types';
 import { parseOpenAPISpec } from './parser.service';
-import { isDirectory, isFile, isYamlFile, findYamlFiles } from '../utils/file-scanner.util';
+import { isDirectory, isFile, isSpecFile, findSpecFiles } from '../utils/file-scanner.util';
 import { ParseError } from '../utils/error-handler.util';
 import { createLogger } from '../utils/logger.util';
 
@@ -8,22 +8,22 @@ const logger = createLogger('multi-spec');
 
 export async function loadSpecsFromPath(specPath: string): Promise<Document[]> {
     if (isFile(specPath)) {
-        if (!isYamlFile(specPath)) {
-            throw new ParseError('File must be a YAML file (.yaml or .yml)');
+        if (!isSpecFile(specPath)) {
+            throw new ParseError('File must be an OpenAPI spec file (.yaml, .yml, or .json)');
         }
         const spec = await parseOpenAPISpec(specPath);
         return [spec];
     }
 
     if (isDirectory(specPath)) {
-        const yamlFiles = findYamlFiles(specPath);
+        const specFiles = findSpecFiles(specPath);
 
-        if (yamlFiles.length === 0) {
-            throw new ParseError(`No YAML files found in directory: ${specPath}`);
+        if (specFiles.length === 0) {
+            throw new ParseError(`No OpenAPI spec files found in directory: ${specPath}`);
         }
 
         const specs: Document[] = [];
-        for (const file of yamlFiles) {
+        for (const file of specFiles) {
             try {
                 const spec = await parseOpenAPISpec(file);
                 specs.push(spec);

--- a/src/utils/file-scanner.util.ts
+++ b/src/utils/file-scanner.util.ts
@@ -17,28 +17,40 @@ export function isFile(filePath: string): boolean {
     }
 }
 
-export function findYamlFiles(dirPath: string): string[] {
+export function findSpecFiles(dirPath: string): string[] {
     if (!isDirectory(dirPath)) {
         return [];
     }
 
-    const yamlFiles: string[] = [];
+    const specFiles: string[] = [];
     const files = fs.readdirSync(dirPath);
 
     for (const file of files) {
         const fullPath = path.join(dirPath, file);
 
         if (isDirectory(fullPath)) {
-            yamlFiles.push(...findYamlFiles(fullPath));
+            specFiles.push(...findSpecFiles(fullPath));
             continue;
         }
 
-        if (isYamlFile(file)) {
-            yamlFiles.push(fullPath);
+        if (isSpecFile(file)) {
+            specFiles.push(fullPath);
         }
     }
 
-    return yamlFiles;
+    return specFiles;
+}
+
+export function isSpecFile(filename: string): boolean {
+    const ext = path.extname(filename).toLowerCase();
+    return ext === '.yaml' || ext === '.yml' || ext === '.json';
+}
+
+export function findYamlFiles(dirPath: string): string[] {
+    return findSpecFiles(dirPath).filter((filePath) => {
+        const ext = path.extname(filePath).toLowerCase();
+        return ext === '.yaml' || ext === '.yml';
+    });
 }
 
 export function isYamlFile(filename: string): boolean {


### PR DESCRIPTION
## Summary
- generalize response selection to choose the lowest available `2xx` status (with sensible fallback behavior)
- shape object mock responses with submitted JSON request bodies, including nested object merging
- add OpenAPI `.json` file support in single-file and directory loading, and update docs/tests accordingly

## Test plan
- [x] Run `npm test`
- [x] Run `npm run lint`
- [ ] Manually run the CLI with a JSON OpenAPI spec and verify routes respond as expected

Closes #22

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core mock response behavior (status-code selection and body shaping), which can alter contract expectations for existing users, though scoped and covered by tests.
> 
> **Overview**
> Adds OpenAPI `.json` support across the CLI and multi-spec loader by generalizing file detection/scanning from YAML-only to YAML+JSON and updating related error messages, tests, and README.
> 
> Updates the mock server to **select the lowest available 2xx response code** (with sensible fallbacks when only non-2xx/default responses exist) and to **shape object JSON responses using fields from the incoming request body**, including recursive merging for nested objects; adds integration tests validating both behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6dc6a06752f11f409e9e1a4350162a5b8cbe9c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->