### PR TITLE
Fix #6: Realistic image and avatar generators

### DIFF
--- a/src/utils/__tests__/image-data.util.test.ts
+++ b/src/utils/__tests__/image-data.util.test.ts
@@ -1,0 +1,43 @@
+import {
+    generateRealisticImage,
+    generateRealisticAvatar,
+    generateRealisticPlaceholder,
+} from '../image-data.util';
+
+describe('Image Data Util', () => {
+    describe('generateRealisticImage', () => {
+        it('should generate a valid picsum URL', () => {
+            const url = generateRealisticImage();
+            expect(url).toMatch(/^https:\/\/picsum\.photos\/id\/\d+\/\d+\/\d+$/);
+        });
+
+        it('should respect custom dimensions', () => {
+            const url = generateRealisticImage(800, 600);
+            expect(url).toContain('800/600');
+        });
+    });
+
+    describe('generateRealisticAvatar', () => {
+        it('should generate a valid pravatar URL', () => {
+            const url = generateRealisticAvatar();
+            expect(url).toMatch(/^https:\/\/i\.pravatar\.cc\/\d+\?u=\d+$/);
+        });
+
+        it('should respect custom size', () => {
+            const url = generateRealisticAvatar(100);
+            expect(url).toContain('100?u=');
+        });
+    });
+
+    describe('generateRealisticPlaceholder', () => {
+        it('should generate a valid placeholder URL', () => {
+            const url = generateRealisticPlaceholder();
+            expect(url).toBe('https://via.placeholder.com/400x400');
+        });
+
+        it('should include custom text', () => {
+            const url = generateRealisticPlaceholder(200, 100, 'Test');
+            expect(url).toBe('https://via.placeholder.com/200x100?text=Test');
+        });
+    });
+});

--- a/src/utils/__tests__/string-generator.util.test.ts
+++ b/src/utils/__tests__/string-generator.util.test.ts
@@ -39,6 +39,16 @@ describe('String Generator Util', () => {
       const url = generateURL();
       expect(url).toMatch(/^https:\/\/example\.com\/resource\/\d+$/);
     });
+
+    it('should generate image URL when containing image keyword', () => {
+      const url = generateURL('productImage');
+      expect(url).toMatch(/^https:\/\/picsum\.photos\/id\/\d+\/400\/400$/);
+    });
+
+    it('should generate avatar URL when containing avatar keyword', () => {
+      const url = generateURL('userAvatar');
+      expect(url).toMatch(/^https:\/\/i\.pravatar\.cc\/200\?u=\d+$/);
+    });
   });
 
   describe('generateDateString', () => {
@@ -97,6 +107,16 @@ describe('String Generator Util', () => {
     it('should generate URL for url property', () => {
       const result = generateStringByPropertyName('website_url');
       expect(result).toMatch(/^https:\/\/example\.com\/resource\/\d+$/);
+    });
+
+    it('should generate image URL for image property', () => {
+      const result = generateStringByPropertyName('cover_image');
+      expect(result).toMatch(/^https:\/\/picsum\.photos\/id\/\d+\/400\/400$/);
+    });
+
+    it('should generate avatar URL for avatar property', () => {
+      const result = generateStringByPropertyName('user_avatar');
+      expect(result).toMatch(/^https:\/\/i\.pravatar\.cc\/200\?u=\d+$/);
     });
 
     it('should return null for unknown property', () => {

--- a/src/utils/image-data.util.ts
+++ b/src/utils/image-data.util.ts
@@ -1,0 +1,16 @@
+import { generateRandomInteger } from './number-generator.util';
+
+export function generateRealisticImage(width = 400, height = 400): string {
+    const id = generateRandomInteger(1, 1000);
+    return `https://picsum.photos/id/${id}/${width}/${height}`;
+}
+
+export function generateRealisticAvatar(size = 200): string {
+    const id = generateRandomInteger(1, 70);
+    return `https://i.pravatar.cc/${size}?u=${id}`;
+}
+
+export function generateRealisticPlaceholder(width = 400, height = 400, text?: string): string {
+    const baseUrl = `https://via.placeholder.com/${width}x${height}`;
+    return text ? `${baseUrl}?text=${encodeURIComponent(text)}` : baseUrl;
+}

--- a/src/utils/string-generator.util.ts
+++ b/src/utils/string-generator.util.ts
@@ -20,6 +20,7 @@ import {
   generateRealisticDescription,
 } from './business-data.util';
 import { generateRealisticCurrency } from './finance-data.util';
+import { generateRealisticImage, generateRealisticAvatar } from './image-data.util';
 
 export function generateUUID(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
@@ -37,7 +38,14 @@ export function generatePhoneNumber(): string {
   return generateRealisticPhone();
 }
 
-export function generateURL(): string {
+export function generateURL(propertyName = ''): string {
+  const lowerProp = propertyName.toLowerCase();
+  if (lowerProp.includes('image') || lowerProp.includes('picture') || lowerProp.includes('photo') || lowerProp.includes('thumbnail')) {
+    return generateRealisticImage();
+  }
+  if (lowerProp.includes('avatar') || lowerProp.includes('profile')) {
+    return generateRealisticAvatar();
+  }
   const randomId = generateRandomInteger(1, 9999);
   return `https://example.com/resource/${randomId}`;
 }
@@ -79,8 +87,8 @@ export function generateStringByPropertyName(propertyName: string): string | nul
     return generatePhoneNumber();
   }
 
-  if (lowerProp.includes('url') || lowerProp.includes('link') || lowerProp.includes('website')) {
-    return generateURL();
+  if (lowerProp.includes('url') || lowerProp.includes('link') || lowerProp.includes('website') || lowerProp.includes('image') || lowerProp.includes('picture') || lowerProp.includes('photo') || lowerProp.includes('avatar')) {
+    return generateURL(propertyName);
   }
 
   if (lowerProp.includes('name') && !lowerProp.includes('user') && !lowerProp.includes('file')) {


### PR DESCRIPTION
This PR addresses issue #6 by adding realistic image and avatar generators using picsum.photos and pravatar.cc.

- Added 
- Updated  to handle image-related property names
- Added unit tests for image generators
- Closes #6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mock string generation behavior for any properties containing image/avatar keywords, potentially affecting downstream tests/fixtures that assumed generic URLs, and introduces reliance on new external URL formats.
> 
> **Overview**
> Adds a new `image-data.util` with generators for realistic image, avatar, and placeholder URLs (picsum/pravatar/via.placeholder), and introduces dedicated unit tests for these helpers.
> 
> Updates `generateURL`/`generateStringByPropertyName` to detect image/avatar-related property names and return the new realistic image/avatar URLs instead of the generic `example.com` URL, with expanded tests covering these new cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 497a3f9316a701ad637d9a4d8dca21ab0071145c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->