### PR TITLE
feat: implement response header mocking

### DIFF
--- a/src/services/__tests__/header-mocking.test.ts
+++ b/src/services/__tests__/header-mocking.test.ts
@@ -1,0 +1,73 @@
+import { startMockServer } from '../server.service';
+import { Document } from '../../types';
+import { Server } from 'http';
+import axios from 'axios';
+
+jest.setTimeout(10000);
+
+describe('Header Mocking', () => {
+    let server: Server | undefined;
+
+    afterEach((done) => {
+        if (!server) {
+            done();
+            return;
+        }
+        server.close(() => {
+            server = undefined;
+            done();
+        });
+    });
+
+    it('should return mocked headers defined in the response spec', async () => {
+        const port = 6100 + Math.floor(Math.random() * 1000);
+        const apiSpec: Document = {
+            openapi: '3.0.0',
+            info: { title: 'Header API', version: '1.0.0' },
+            paths: {
+                '/test-headers': {
+                    get: {
+                        responses: {
+                            '200': {
+                                description: 'OK',
+                                headers: {
+                                    'X-Custom-Header': {
+                                        schema: {
+                                            type: 'string',
+                                            example: 'custom-value'
+                                        },
+                                        description: 'A custom header'
+                                    },
+                                    'X-Rate-Limit': {
+                                        schema: {
+                                            type: 'integer',
+                                            example: 100
+                                        },
+                                        description: 'Rate limit'
+                                    }
+                                },
+                                content: {
+                                    'application/json': {
+                                        schema: {
+                                            type: 'object',
+                                            properties: {
+                                                message: { type: 'string' }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        server = await startMockServer(apiSpec, port);
+        const response = await axios.get(`http://localhost:${port}/test-headers`);
+
+        expect(response.status).toBe(200);
+        expect(response.headers['x-custom-header']).toBe('custom-value');
+        expect(response.headers['x-rate-limit']).toBe('100'); // Axios converts headers to lowercase and values to string
+    });
+});

--- a/src/services/mock-generator.service.ts
+++ b/src/services/mock-generator.service.ts
@@ -26,6 +26,29 @@ export function generateMockResponse(responseSchema: ResponseObject): unknown {
     return generateMockData(jsonContent.schema as SchemaObject);
 }
 
+export function generateMockHeaders(responseSchema: ResponseObject): Record<string, string> {
+    const headers: Record<string, string> = {};
+
+    if (!responseSchema.headers) {
+        return headers;
+    }
+
+    for (const [name, headerSpec] of Object.entries(responseSchema.headers)) {
+        if ('$ref' in headerSpec) {
+            continue; // Basic implementation, skipping refs for now
+        }
+
+        if (headerSpec.schema) {
+            const mockValue = generateMockData(headerSpec.schema as SchemaObject, name);
+            headers[name] = String(mockValue);
+        } else if (headerSpec.example !== undefined) {
+            headers[name] = String(headerSpec.example);
+        }
+    }
+
+    return headers;
+}
+
 export function generateMockData(schema: SchemaObject, propertyName = ''): unknown {
     if (schema.example !== undefined) {
         return schema.example;

--- a/src/services/server.service.ts
+++ b/src/services/server.service.ts
@@ -2,216 +2,217 @@ import express, { Request, Response, NextFunction, Application } from 'express';
 import { Server } from 'http';
 import swaggerUi from 'swagger-ui-express';
 import { Document, OperationObject, ParameterObject, ResponseObject } from '../types';
-import { generateMockResponse } from './mock-generator.service';
+import { generateMockResponse, generateMockHeaders } from './mock-generator.service';
 import { ValidationError } from '../utils/error-handler.util';
 import { createLogger } from '../utils/logger.util';
 
 const logger = createLogger('server');
 
 export async function startMockServer(apiSpec: Document, port: number): Promise<Server> {
-  const app = express();
-  setupMiddleware(app);
-  setupSwaggerUI(app, apiSpec);
-  registerRoutes(app, apiSpec);
-  setupErrorHandlers(app);
+    const app = express();
+    setupMiddleware(app);
+    setupSwaggerUI(app, apiSpec);
+    registerRoutes(app, apiSpec);
+    setupErrorHandlers(app);
 
-  return new Promise((resolve) => {
-    const server = app.listen(port, () => {
-      resolve(server);
+    return new Promise((resolve) => {
+        const server = app.listen(port, () => {
+            resolve(server);
+        });
     });
-  });
 }
 
 function setupMiddleware(app: Application): void {
-  app.use(express.json());
-  app.use((_req: Request, res: Response, next: NextFunction) => {
-    res.header('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS');
-    res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    next();
-  });
+    app.use(express.json());
+    app.use((_req: Request, res: Response, next: NextFunction) => {
+        res.header('Access-Control-Allow-Origin', '*');
+        res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS');
+        res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+        next();
+    });
 }
 
 function setupSwaggerUI(app: Application, apiSpec: Document): void {
-  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(apiSpec));
+    app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(apiSpec));
 }
 
 function registerRoutes(app: Application, apiSpec: Document): void {
-  if (!apiSpec.paths) {
-    return;
-  }
-
-  for (const [path, pathItem] of Object.entries(apiSpec.paths)) {
-    if (!pathItem) {
-      continue;
+    if (!apiSpec.paths) {
+        return;
     }
 
-    for (const [method, operation] of Object.entries(pathItem)) {
-      if (method === 'parameters' || !isValidHttpMethod(method)) {
-        continue;
-      }
+    for (const [path, pathItem] of Object.entries(apiSpec.paths)) {
+        if (!pathItem) {
+            continue;
+        }
 
-      const expressPath = convertToExpressPath(path);
-      const httpMethod = method.toLowerCase() as keyof Application;
+        for (const [method, operation] of Object.entries(pathItem)) {
+            if (method === 'parameters' || !isValidHttpMethod(method)) {
+                continue;
+            }
 
-      app[httpMethod](expressPath, createRouteHandler(operation as OperationObject));
-      app.options(expressPath, handleOptionsRequest(method));
+            const expressPath = convertToExpressPath(path);
+            const httpMethod = method.toLowerCase() as keyof Application;
+
+            app[httpMethod](expressPath, createRouteHandler(operation as OperationObject));
+            app.options(expressPath, handleOptionsRequest(method));
+        }
     }
-  }
 }
 
 function isValidHttpMethod(method: string): boolean {
-  const validMethods = ['get', 'post', 'put', 'delete', 'patch', 'options', 'head'];
-  return validMethods.includes(method.toLowerCase());
+    const validMethods = ['get', 'post', 'put', 'delete', 'patch', 'options', 'head'];
+    return validMethods.includes(method.toLowerCase());
 }
 
 function convertToExpressPath(openApiPath: string): string {
-  return openApiPath.replace(/{([^}]+)}/g, ':$1');
+    return openApiPath.replace(/{([^}]+)}/g, ':$1');
 }
 
 function createRouteHandler(operation: OperationObject): (req: Request, res: Response) => void {
-  return (req: Request, res: Response): void => {
-    try {
-      validateRequiredParameters(req, operation);
-      const { responseSpec, statusCode } = selectResponse(operation);
-      const mockResponse = generateMockResponse(responseSpec);
-      const response = applyRequestBodyShape(req.body, mockResponse);
+    return (req: Request, res: Response): void => {
+        try {
+            validateRequiredParameters(req, operation);
+            const { responseSpec, statusCode } = selectResponse(operation);
+            const mockResponse = generateMockResponse(responseSpec);
+            const mockHeaders = generateMockHeaders(responseSpec);
+            const response = applyRequestBodyShape(req.body, mockResponse);
 
-      res.status(statusCode).json(response);
-    } catch (error) {
-      if (error instanceof ValidationError) {
-        res.status(400).json({ error: error.message });
-        return;
-      }
-      throw error;
-    }
-  };
+            res.status(statusCode).set(mockHeaders).json(response);
+        } catch (error) {
+            if (error instanceof ValidationError) {
+                res.status(400).json({ error: error.message });
+                return;
+            }
+            throw error;
+        }
+    };
 }
 
 function validateRequiredParameters(req: Request, operation: OperationObject): void {
-  if (!operation.parameters) {
-    return;
-  }
-
-  const queryParams = operation.parameters.filter(
-    (p) => (p as ParameterObject).in === 'query'
-  ) as ParameterObject[];
-
-  for (const param of queryParams) {
-    if (param.required && !req.query[param.name]) {
-      throw new ValidationError(`Missing required query parameter: ${param.name}`);
+    if (!operation.parameters) {
+        return;
     }
-  }
+
+    const queryParams = operation.parameters.filter(
+        (p) => (p as ParameterObject).in === 'query'
+    ) as ParameterObject[];
+
+    for (const param of queryParams) {
+        if (param.required && !req.query[param.name]) {
+            throw new ValidationError(`Missing required query parameter: ${param.name}`);
+        }
+    }
 }
 
 function selectResponse(operation: OperationObject): {
-  responseSpec: ResponseObject;
-  statusCode: number;
+    responseSpec: ResponseObject;
+    statusCode: number;
 } {
-  if (!operation.responses) {
-    return { responseSpec: { description: 'No response defined' }, statusCode: 200 };
-  }
-
-  const responseEntries = Object.entries(operation.responses).filter(([code]) =>
-    /^\d{3}$/.test(code)
-  );
-  if (responseEntries.length === 0) {
-    const defaultResponse = operation.responses.default;
-    if (isResponseObject(defaultResponse)) {
-      return { responseSpec: defaultResponse, statusCode: 200 };
+    if (!operation.responses) {
+        return { responseSpec: { description: 'No response defined' }, statusCode: 200 };
     }
 
-    return { responseSpec: { description: 'Default response' }, statusCode: 200 };
-  }
+    const responseEntries = Object.entries(operation.responses).filter(([code]) =>
+        /^\d{3}$/.test(code)
+    );
+    if (responseEntries.length === 0) {
+        const defaultResponse = operation.responses.default;
+        if (isResponseObject(defaultResponse)) {
+            return { responseSpec: defaultResponse, statusCode: 200 };
+        }
 
-  const successfulResponses = responseEntries
-    .map(([code, response]) => ({ code: Number(code), response }))
-    .filter(({ code }) => code >= 200 && code < 300)
-    .sort((a, b) => a.code - b.code);
-  if (successfulResponses.length > 0) {
-    const selected = successfulResponses[0];
-    if (isResponseObject(selected.response)) {
-      return { responseSpec: selected.response, statusCode: selected.code };
+        return { responseSpec: { description: 'Default response' }, statusCode: 200 };
     }
-  }
 
-  const allResponses = responseEntries
-    .map(([code, response]) => ({ code: Number(code), response }))
-    .sort((a, b) => a.code - b.code);
-  const selected = allResponses[0];
-  if (!selected || !isResponseObject(selected.response)) {
-    return { responseSpec: { description: 'Default response' }, statusCode: 200 };
-  }
+    const successfulResponses = responseEntries
+        .map(([code, response]) => ({ code: Number(code), response }))
+        .filter(({ code }) => code >= 200 && code < 300)
+        .sort((a, b) => a.code - b.code);
+    if (successfulResponses.length > 0) {
+        const selected = successfulResponses[0];
+        if (isResponseObject(selected.response)) {
+            return { responseSpec: selected.response, statusCode: selected.code };
+        }
+    }
 
-  return { responseSpec: selected.response, statusCode: selected.code };
+    const allResponses = responseEntries
+        .map(([code, response]) => ({ code: Number(code), response }))
+        .sort((a, b) => a.code - b.code);
+    const selected = allResponses[0];
+    if (!selected || !isResponseObject(selected.response)) {
+        return { responseSpec: { description: 'Default response' }, statusCode: 200 };
+    }
+
+    return { responseSpec: selected.response, statusCode: selected.code };
 }
 
 function isResponseObject(response: unknown): response is ResponseObject {
-  if (!response || typeof response !== 'object') {
-    return false;
-  }
+    if (!response || typeof response !== 'object') {
+        return false;
+    }
 
-  return !('$ref' in response);
+    return !('$ref' in response);
 }
 
 function applyRequestBodyShape(requestBody: unknown, mockResponse: unknown): unknown {
-  if (!isRecord(mockResponse)) {
-    return mockResponse;
-  }
+    if (!isRecord(mockResponse)) {
+        return mockResponse;
+    }
 
-  if (!isRecord(requestBody)) {
-    return mockResponse;
-  }
+    if (!isRecord(requestBody)) {
+        return mockResponse;
+    }
 
-  return mergeResponseWithRequestBody(mockResponse, requestBody);
+    return mergeResponseWithRequestBody(mockResponse, requestBody);
 }
 
 function mergeResponseWithRequestBody(
-  mockResponse: Record<string, unknown>,
-  requestBody: Record<string, unknown>
+    mockResponse: Record<string, unknown>,
+    requestBody: Record<string, unknown>
 ): Record<string, unknown> {
-  const merged: Record<string, unknown> = { ...mockResponse };
+    const merged: Record<string, unknown> = { ...mockResponse };
 
-  for (const [key, value] of Object.entries(requestBody)) {
-    if (isRecord(value) && isRecord(merged[key])) {
-      merged[key] = mergeResponseWithRequestBody(merged[key] as Record<string, unknown>, value);
-      continue;
+    for (const [key, value] of Object.entries(requestBody)) {
+        if (isRecord(value) && isRecord(merged[key])) {
+            merged[key] = mergeResponseWithRequestBody(merged[key] as Record<string, unknown>, value);
+            continue;
+        }
+
+        merged[key] = value;
     }
 
-    merged[key] = value;
-  }
-
-  return merged;
+    return merged;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
 
-  return !Array.isArray(value);
+    return !Array.isArray(value);
 }
 
 function handleOptionsRequest(method: string): (req: Request, res: Response) => void {
-  return (_req: Request, res: Response): void => {
-    res.header('Access-Control-Allow-Methods', method.toUpperCase());
-    res.sendStatus(200);
-  };
+    return (_req: Request, res: Response): void => {
+        res.header('Access-Control-Allow-Methods', method.toUpperCase());
+        res.sendStatus(200);
+    };
 }
 
 function setupErrorHandlers(app: Application): void {
-  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
-    logger.error(err.stack ?? err.message);
-    res.status(500).json({
-      error: 'Internal Server Error',
-      message: err.message,
+    app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+        logger.error(err.stack ?? err.message);
+        res.status(500).json({
+            error: 'Internal Server Error',
+            message: err.message,
+        });
     });
-  });
 
-  app.use((_req: Request, res: Response) => {
-    res.status(404).json({
-      error: 'Not Found',
-      message: 'The requested endpoint does not exist',
+    app.use((_req: Request, res: Response) => {
+        res.status(404).json({
+            error: 'Not Found',
+            message: 'The requested endpoint does not exist',
+        });
     });
-  });
 }


### PR DESCRIPTION
Closes #10. This PR adds support for mocking response headers based on the OpenAPI specification.