### PR TITLE
Feat: Support for authentication schemes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@apidevtools/swagger-parser": "^12.1.0",
         "commander": "^14.0.3",
+        "cookie-parser": "^1.4.7",
         "express": "^5.2.1",
         "js-yaml": "^4.1.1",
         "pino": "^10.3.1",
@@ -20,6 +21,7 @@
         "rest-mock": "dist/index.js"
       },
       "devDependencies": {
+        "@types/cookie-parser": "^1.4.10",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.2.2",
@@ -1650,6 +1652,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -3131,13 +3143,32 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -50,12 +50,14 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",
     "commander": "^14.0.3",
+    "cookie-parser": "^1.4.7",
     "express": "^5.2.1",
     "js-yaml": "^4.1.1",
     "pino": "^10.3.1",
     "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.10",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.2.2",

--- a/src/services/__tests__/auth-e2e.test.ts
+++ b/src/services/__tests__/auth-e2e.test.ts
@@ -1,0 +1,163 @@
+import { startMockServer } from '../server.service';
+import { Document } from '../../types';
+import { Server } from 'http';
+import axios from 'axios';
+
+jest.setTimeout(10000);
+
+describe('Auth Validation E2E', () => {
+    let server: Server | undefined;
+    const port = 6000 + Math.floor(Math.random() * 1000);
+
+    afterEach((done) => {
+        if (!server) {
+            done();
+            return;
+        }
+        server.close(() => {
+            server = undefined;
+            done();
+        });
+    });
+
+    const apiSpec: Document = {
+        openapi: '3.0.0',
+        info: { title: 'Auth API', version: '1.0.0' },
+        components: {
+            securitySchemes: {
+                apiKeyHeader: {
+                    type: 'apiKey',
+                    in: 'header',
+                    name: 'X-API-Key',
+                },
+                apiKeyQuery: {
+                    type: 'apiKey',
+                    in: 'query',
+                    name: 'api_key',
+                },
+                basicAuth: {
+                    type: 'http',
+                    scheme: 'basic',
+                },
+                bearerAuth: {
+                    type: 'http',
+                    scheme: 'bearer',
+                },
+            },
+        },
+        paths: {
+            '/secure-api-key-header': {
+                get: {
+                    security: [{ apiKeyHeader: [] }],
+                    responses: { '200': { description: 'OK' } },
+                },
+            },
+            '/secure-api-key-query': {
+                get: {
+                    security: [{ apiKeyQuery: [] }],
+                    responses: { '200': { description: 'OK' } },
+                },
+            },
+            '/secure-basic': {
+                get: {
+                    security: [{ basicAuth: [] }],
+                    responses: { '200': { description: 'OK' } },
+                },
+            },
+            '/secure-bearer': {
+                get: {
+                    security: [{ bearerAuth: [] }],
+                    responses: { '200': { description: 'OK' } },
+                },
+            },
+            '/secure-multiple': {
+                get: {
+                    security: [{ apiKeyHeader: [] }, { basicAuth: [] }],
+                    responses: { '200': { description: 'OK' } },
+                },
+            },
+        },
+    };
+
+    beforeEach(async () => {
+        server = await startMockServer(apiSpec, port);
+    });
+
+    describe('API Key Authentication', () => {
+        it('should allow request with valid header API key', async () => {
+            const response = await axios.get(`http://localhost:${port}/secure-api-key-header`, {
+                headers: { 'X-API-Key': 'test-key' },
+            });
+            expect(response.status).toBe(200);
+        });
+
+        it('should fail request with missing header API key', async () => {
+            try {
+                await axios.get(`http://localhost:${port}/secure-api-key-header`);
+                fail('Should have failed');
+            } catch (error: any) {
+                expect(error.response.status).toBe(400);
+                expect(error.response.data.error).toContain('Missing API key "X-API-Key" in header');
+            }
+        });
+
+        it('should allow request with valid query API key', async () => {
+            const response = await axios.get(`http://localhost:${port}/secure-api-key-query?api_key=test-key`);
+            expect(response.status).toBe(200);
+        });
+    });
+
+    describe('HTTP Authentication', () => {
+        it('should allow valid Basic auth', async () => {
+            const response = await axios.get(`http://localhost:${port}/secure-basic`, {
+                headers: { Authorization: 'Basic dGVzdDp0ZXN0' },
+            });
+            expect(response.status).toBe(200);
+        });
+
+        it('should fail invalid Basic auth prefix', async () => {
+            try {
+                await axios.get(`http://localhost:${port}/secure-basic`, {
+                    headers: { Authorization: 'Bearer dGVzdA==' },
+                });
+                fail('Should have failed');
+            } catch (error: any) {
+                expect(error.response.status).toBe(400);
+                expect(error.response.data.error).toContain('Authorization header must be Basic');
+            }
+        });
+
+        it('should allow valid Bearer auth', async () => {
+            const response = await axios.get(`http://localhost:${port}/secure-bearer`, {
+                headers: { Authorization: 'Bearer test-token' },
+            });
+            expect(response.status).toBe(200);
+        });
+    });
+
+    describe('Multiple Security Requirements (OR logic)', () => {
+        it('should allow if first requirement is met', async () => {
+            const response = await axios.get(`http://localhost:${port}/secure-multiple`, {
+                headers: { 'X-API-Key': 'test-key' },
+            });
+            expect(response.status).toBe(200);
+        });
+
+        it('should allow if second requirement is met', async () => {
+            const response = await axios.get(`http://localhost:${port}/secure-multiple`, {
+                headers: { Authorization: 'Basic dGVzdDp0ZXN0' },
+            });
+            expect(response.status).toBe(200);
+        });
+
+        it('should fail if neither requirement is met', async () => {
+            try {
+                await axios.get(`http://localhost:${port}/secure-multiple`);
+                fail('Should have failed');
+            } catch (error: any) {
+                expect(error.response.status).toBe(400);
+                expect(error.response.data.error).toContain('Authentication failed');
+            }
+        });
+    });
+});

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,129 @@
+import { Request } from 'express';
+import { OpenAPIV3 } from 'openapi-types';
+import { ValidationError } from '../utils/error-handler.util';
+
+export function validateSecurity(
+    req: Request,
+    operation: OpenAPIV3.OperationObject,
+    apiSpec: OpenAPIV3.Document
+): void {
+    const security = operation.security ?? apiSpec.security;
+
+    if (!security || security.length === 0) {
+        return;
+    }
+
+    // Security is an array of requirements. Any one of them must be satisfied (OR logic).
+    // Each requirement is an object where keys are security scheme names (AND logic within the object).
+    const securitySchemes = apiSpec.components?.securitySchemes;
+
+    if (!securitySchemes) {
+        // If security is required but no schemes are defined, we might want to warn or fail.
+        // For now, if security is defined on the operation but no schemes exist, we'll assume it's an invalid spec
+        // but let's be lenient or check if it matches common patterns.
+        return;
+    }
+
+    const errors: string[] = [];
+
+    for (const requirement of security) {
+        let allMet = true;
+        const requirementErrors: string[] = [];
+
+        for (const [schemeName] of Object.entries(requirement)) {
+            const scheme = securitySchemes[schemeName];
+            if (!scheme) {
+                requirementErrors.push(`Security scheme "${schemeName}" not found in components/securitySchemes`);
+                allMet = false;
+                continue;
+            }
+
+            // Type guard for ReferenceObject
+            if ('$ref' in scheme) {
+                continue; // We don't handle $ref for security schemes yet
+            }
+
+            try {
+                validateScheme(req, scheme as OpenAPIV3.SecuritySchemeObject);
+            } catch (error) {
+                if (error instanceof Error) {
+                    requirementErrors.push(error.message);
+                }
+                allMet = false;
+            }
+        }
+
+        if (allMet) {
+            return; // At least one requirement met
+        }
+
+        errors.push(`Requirement [${Object.keys(requirement).join(', ')}] failed: ${requirementErrors.join('; ')}`);
+    }
+
+    throw new ValidationError(`Authentication failed: ${errors.join(' OR ')}`);
+}
+
+function validateScheme(req: Request, scheme: OpenAPIV3.SecuritySchemeObject): void {
+    switch (scheme.type) {
+        case 'apiKey':
+            validateApiKey(req, scheme as OpenAPIV3.ApiKeySecurityScheme);
+            break;
+        case 'http':
+            validateHttpSecurity(req, scheme as OpenAPIV3.HttpSecurityScheme);
+            break;
+        case 'oauth2':
+        case 'openIdConnect':
+            validateBearerToken(req);
+            break;
+        default:
+            // For now, accept unknown types if present (be lenient)
+            break;
+    }
+}
+
+function validateApiKey(req: Request, scheme: OpenAPIV3.ApiKeySecurityScheme): void {
+    const { name, in: location } = scheme;
+    let value: string | undefined;
+
+    switch (location) {
+        case 'header':
+            value = req.header(name);
+            break;
+        case 'query':
+            value = req.query[name] as string;
+            break;
+        case 'cookie':
+            value = req.cookies?.[name];
+            break;
+    }
+
+    if (!value) {
+        throw new Error(`Missing API key "${name}" in ${location}`);
+    }
+}
+
+function validateHttpSecurity(req: Request, scheme: OpenAPIV3.HttpSecurityScheme): void {
+    const authHeader = req.header('Authorization');
+    if (!authHeader) {
+        throw new Error('Missing Authorization header');
+    }
+
+    const schemeName = scheme.scheme?.toLowerCase();
+
+    if (schemeName === 'basic') {
+        if (!authHeader.toLowerCase().startsWith('basic ')) {
+            throw new Error('Authorization header must be Basic');
+        }
+    } else if (schemeName === 'bearer') {
+        if (!authHeader.toLowerCase().startsWith('bearer ')) {
+            throw new Error('Authorization header must be Bearer');
+        }
+    }
+}
+
+function validateBearerToken(req: Request): void {
+    const authHeader = req.header('Authorization');
+    if (!authHeader || !authHeader.toLowerCase().startsWith('bearer ')) {
+        throw new Error('Missing or invalid Bearer token in Authorization header');
+    }
+}


### PR DESCRIPTION
Closes #11. Adds support for Basic, Bearer, and API Key authentication schemes as defined in OpenAPI specifications.